### PR TITLE
fix(auth): sửa lỗi chuyển hướng sai trang khi đăng nhập thất bại

### DIFF
--- a/backend/app/api/auth/github_oauth.py
+++ b/backend/app/api/auth/github_oauth.py
@@ -83,18 +83,22 @@ async def github_callback(
 ):
     if not code or not state:
         # raise HTTPException(400, "Thiếu code/state")
-        raise HTTPException(400 ,"Đăng nhập thất bại ")
+        url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+        return RedirectResponse(url, status_code=302)
 
     oauth_map: dict = request.session.get("oauth_map", {})
     entry = oauth_map.get(state)
     if entry is None:
         # raise HTTPException(400, "State không hợp lệ/expired")
-        raise HTTPException(400 ,"Đăng nhập thất bại ")
+        url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+        return RedirectResponse(url, status_code=302)
 
     verifier = entry.get("verifier") if USE_PKCE else None
     if USE_PKCE and not verifier:
         # raise HTTPException(400, "Thiếu code_verifier (session/PKCE)")
-        raise HTTPException(400 ,"Đăng nhập thất bại ")
+        # đăng nhập thất bại trả về trang login
+        url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+        return RedirectResponse(url, status_code=302)
 
     token_payload = {
         "client_id": settings.GITHUB_CLIENT_ID,
@@ -112,12 +116,16 @@ async def github_callback(
             headers={"Accept": "application/json"},
         )
         if token_res.status_code != 200:
-            raise HTTPException(400, f"Đổi token thất bại: {token_res.text}")
+            # raise HTTPException(400, f"Đổi token thất bại: {token_res.text}")
+            url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+            return RedirectResponse(url, status_code=302)
 
         token_json = token_res.json()
         access_token = token_json.get("access_token")
         if not access_token:
-            raise HTTPException(400, f"Thiếu access_token từ GitHub: {token_json}")
+            # raise HTTPException(400, f"Thiếu access_token từ GitHub: {token_json}")
+            url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+            return RedirectResponse(url, status_code=302)
 
         ui_res = await client.get(
             GITHUB_USER_URL,
@@ -145,7 +153,8 @@ async def github_callback(
     full_name = ui.get("name") or login_name
     avatar_url = ui.get("avatar_url")
     if not github_id:
-        raise HTTPException(400, "Thiếu id (provider_user_id) từ GitHub")
+        url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+        return RedirectResponse(url, status_code=302)
 
     provider_val = getattr(Provider.GITHUB, "value", Provider.GITHUB)
 

--- a/backend/app/api/auth/google_oauth.py
+++ b/backend/app/api/auth/google_oauth.py
@@ -79,18 +79,21 @@ async def google_callback(request: Request, db: Session = Depends(get_db)):
 
     if not code or not state:
         # raise HTTPException(400, "Thiếu code hoặc state")
-        raise HTTPException(400 ,"Đăng nhập thất bại ")
+        url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+        return RedirectResponse(url, status_code=302)
 
     sess = request.session.get("oauth")
     print("SESSION OAUTH:", sess)
     if not sess or sess.get("state") != state:
         # raise HTTPException(400, "State không hợp lệ (không khớp session)")
-        raise HTTPException(400 ,"Đăng nhập thất bại ")
+        url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+        return RedirectResponse(url, status_code=302)
 
     verifier = sess.get("verifier") if USE_PKCE else None
     if USE_PKCE and not verifier:
         # raise HTTPException(400, "Thiếu code_verifier (session/PKCE)")
-        raise HTTPException(400 ,"Đăng nhập thất bại ")
+        url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+        return RedirectResponse(url, status_code=302)
 
     #Lấy thông tin user
     token_payload = {
@@ -117,13 +120,15 @@ async def google_callback(request: Request, db: Session = Depends(get_db)):
 
         if token_res.status_code != 200:
             # raise HTTPException(400, f"Đổi token thất bại: {token_res.text}")
-            raise HTTPException(400 ,"Đăng nhập thất bại ")
+            url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+            return RedirectResponse(url, status_code=302)
 
         token_json = token_res.json()
         access_token = token_json.get("access_token")
         if not access_token:
             # raise HTTPException(400, f"Thiếu access_token từ Google: {token_json}")
-            raise HTTPException(400 ,"Đăng nhập thất bại ")
+            url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+            return RedirectResponse(url, status_code=302)
 
         ui_res = await client.get(
             GOOGLE_USERINFO_URL,
@@ -133,7 +138,8 @@ async def google_callback(request: Request, db: Session = Depends(get_db)):
         print("USERINFO RES BODY:", ui_res.text)
         if ui_res.status_code != 200:
             # raise HTTPException(400, f"Lấy userinfo thất bại: {ui_res.text}")
-            raise HTTPException(400 ,"Đăng nhập thất bại ")
+            url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+            return RedirectResponse(url, status_code=302)
         ui = ui_res.json()
 
     google_sub = ui.get("sub")
@@ -141,9 +147,11 @@ async def google_callback(request: Request, db: Session = Depends(get_db)):
     full_name = ui.get("name")
     avatar = ui.get("picture")
     if not google_sub:
-        raise HTTPException(400, "Thiếu sub (provider_user_id)")
+        url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+        return RedirectResponse(url, status_code=302)
     if not email:
-        raise HTTPException(400, "Google không cung cấp email cho tài khoản này")
+        url = f"{settings.FRONTEND_ORIGIN}/login?error=failed"
+        return RedirectResponse(url, status_code=302)
 
     try:
         identity = (

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,8 @@
-// LoginPage.tsx
 import { Github, Chrome, Sparkles } from "lucide-react";
+import ErrorPanel from "../components/home/ErrorPanel";
+import { useLocation } from "react-router-dom";
 import "../styles/login.css"
+import { useEffect, useState } from "react";
 
 const GoogleLogin = () => {
   window.location.href = `${import.meta.env.VITE_API_BASE}/auth/google/login`
@@ -11,6 +13,29 @@ const GitHubLogin = () => {
 }
 
 export default function LoginPage() {
+
+  const { search } = useLocation();
+  const [errorOpen, setErrorOpen] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const error = params.get("error");
+
+    if (error) {
+      switch (error) {
+        case "failed":
+          setErrorMsg("Đăng nhập thất bại. Vui lòng thử lại!");
+          break;
+        case "oauth_failed":
+          setErrorMsg("Lỗi xác thực OAuth. Vui lòng đăng nhập lại.");
+          break;
+        default:
+          setErrorMsg("Đăng nhập thất bại. Vui lòng thử lại sau.");
+      }
+      setErrorOpen(true);
+    }
+  }, [search]);
   return (
     <div className="login-page">
       <div className="animated-background">
@@ -70,6 +95,12 @@ export default function LoginPage() {
         </div>
 
       </div>
+      <ErrorPanel
+        open={errorOpen}
+        title="Đăng nhập thất bại"
+        message={errorMsg}
+        onClose={() => setErrorOpen(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
- Sửa lỗi redirect sai trang sau khi người dùng đăng nhập thất bại.
- Bổ sung xử lý trả về đúng trang đăng nhập kèm thông báo lỗi rõ ràng.
- Cập nhật logic trong `google_oauth.py` và `github_oauth.py`.

Đã test
- Đăng nhập bằng tài khoản không hợp lệ → hiển thị thông báo lỗi và giữ nguyên trang đăng nhập.
- Đăng nhập thành công → chuyển đúng trang dashboard.
- Kiểm tra cả Google & GitHub OAuth → hoạt động ổn định.
